### PR TITLE
Fix image pixelated when DPR is not an integer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-configtool (5.1.2-1deepin2) unstable; urgency=medium
+
+  * fix #7166
+
+ -- Mike Chen <chenke@deepin.org>  Mon, 26 Feb 2024 11:33:48 +0800
+
 fcitx5-configtool (5.1.2-1deepin1) unstable; urgency=medium
 
   * add Fix_6417_not_loading_qt_translations.patch.

--- a/debian/patches/Fix_7166_image_pixelated.patch
+++ b/debian/patches/Fix_7166_image_pixelated.patch
@@ -1,0 +1,15 @@
+diff --git a/layout/keyboardlayoutwidget.cpp b/layout/keyboardlayoutwidget.cpp
+index d753ab4..f705733 100644
+--- a/layout/keyboardlayoutwidget.cpp
++++ b/layout/keyboardlayoutwidget.cpp
+@@ -676,8 +676,8 @@ void KeyboardLayoutWidget::generatePixmap(bool force) {
+     if (w == image.width() && h == image.height() && !force)
+         return;
+ 
+-    image = QPixmap(QSize(w, h) * devicePixelRatio());
+-    image.setDevicePixelRatio(devicePixelRatio());
++    image = QPixmap(QSize(w, h) * devicePixelRatioF());
++    image.setDevicePixelRatio(devicePixelRatioF());
+     image.fill(Qt::transparent);
+     QPainter painter(&image);
+     painter.setRenderHint(QPainter::Antialiasing, true);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,2 +1,3 @@
 0002-make-Fcitx5Migrator-static.patch
 Fix_6417_not_loading_qt_translations.patch
+Fix_7166_image_pixelated.patch


### PR DESCRIPTION
use devicePixelRatioF() instead of devicePixelRatio()

Issue: https://github.com/linuxdeepin/developer-center/issues/7166