### PR TITLE
chore: don't display the desktop entry of keyboard layout viewer

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fcitx5-configtool (5.1.2-1deepin6) unstable; urgency=medium
+
+  * Don't display the desktop entry of keyboard layout viewer
+
+ -- zsien <quezhiyong@deepin.org>  Tue, 21 May 2024 15:30:17 +0800
+
 fcitx5-configtool (5.1.2-1deepin5) unstable; urgency=medium
 
   * Add Fix_select_all_checkbox_inconsistent.patch.

--- a/debian/patches/0008-don-t-display-the-desktop-entry-of-keyboard-layout-v.patch
+++ b/debian/patches/0008-don-t-display-the-desktop-entry-of-keyboard-layout-v.patch
@@ -1,0 +1,20 @@
+From: zsien <quezhiyong@deepin.org>
+Date: Tue, 21 May 2024 14:54:09 +0800
+Subject: don't display the desktop entry of keyboard layout viewer
+
+---
+ layout/kbd-layout-viewer5.desktop.in | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/layout/kbd-layout-viewer5.desktop.in b/layout/kbd-layout-viewer5.desktop.in
+index 9b96b1c..5066c32 100644
+--- a/layout/kbd-layout-viewer5.desktop.in
++++ b/layout/kbd-layout-viewer5.desktop.in
+@@ -2,6 +2,7 @@
+ Exec=kbd-layout-viewer5
+ Icon=input-keyboard
+ Type=Application
++NoDisplay=true
+ 
+ Name=Keyboard layout viewer
+ Comment=View keyboard layout

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -5,3 +5,4 @@ Fix_6900_Return_key_drawn_tweak.patch
 Fix_7443_fcitx5-migrator_HiDPI.patch
 Fix_7442_not_loading_qt_translations.patch
 Fix_select_all_checkbox_inconsistent.patch
+0008-don-t-display-the-desktop-entry-of-keyboard-layout-v.patch


### PR DESCRIPTION
隐藏启动器图标，不向用户展示